### PR TITLE
实现 JmHtmlClient#getComments 方法

### DIFF
--- a/jmcomic-api/src/main/java/io/github/jukomu/jmcomic/api/model/JmComment.java
+++ b/jmcomic-api/src/main/java/io/github/jukomu/jmcomic/api/model/JmComment.java
@@ -88,7 +88,7 @@ public record JmComment(
         /*
           剧透标记。
          */
-        String spoiler,
+        boolean spoiler,
         /*
           该评论下的回复列表。
          */
@@ -137,7 +137,7 @@ public record JmComment(
                 "",
                 "",
                 "",
-                "",
+                false,
                 replys,
                 voteUp,
                 voteDown
@@ -320,7 +320,7 @@ public record JmComment(
      *
      * @return 剧透标记
      */
-    public String getSpoiler() {
+    public boolean isSpoiler() {
         return spoiler;
     }
 

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmHtmlClient.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmHtmlClient.java
@@ -373,9 +373,33 @@ public final class JmHtmlClient extends AbstractJmClient implements JmNovelClien
         }
     }
 
+    /**
+     * 获取论坛评论列表, HTML 只支持获取本子评论
+     *
+     * @param query 论坛查询参数（见 {@link ForumQuery} 静态工厂方法）
+     * @return 评论列表的一页结果
+     */
     @Override
     public JmCommentList getComments(ForumQuery query) {
-        throw new UnsupportedOperationException("Getting comment list via HTML client is not currently supported. Use JmApiClient instead.");
+        if (!"aid".equals(query.getIdParam())) {
+            throw new UnsupportedOperationException("HTML client currently supports album comments only. Use JmApiClient for novel, blog, or user forum queries.");
+        }
+        if (query.getChapterId() != null && !query.getChapterId().isEmpty()) {
+            throw new UnsupportedOperationException("HTML client does not support chapter-scoped forum queries. Use JmApiClient instead.");
+        }
+
+        String albumId = query.getEntityId();
+        HttpUrl url = newHttpUrlBuilder()
+                .addPathSegment("ajax")
+                .addPathSegment("album_pagination")
+                .build();
+        RequestBody body = new FormBody.Builder()
+                .add("video_id", albumId)
+                .add("page", String.valueOf(query.getPage()))
+                .build();
+
+        JmHtmlResponse response = executePostRequest(url, body);
+        return HtmlParser.parseAlbumCommentsAjax(response.getHtml(), albumId);
     }
 
     @Override

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ApiParser.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ApiParser.java
@@ -884,7 +884,7 @@ public final class ApiParser {
         String gender = getJsonFieldAsString(node, "gender");
         String updateAt = getJsonFieldAsString(node, "update_at");
         String parentCommentId = getJsonFieldAsString(node, "parent_CID");
-        String spoiler = getJsonFieldAsString(node, "spoiler");
+        boolean spoiler = !getJsonFieldAsString(node, "spoiler").equals("1");
 
         // 构建完整的用户头像URL: https://{imageDomain}/media/users/{photo}
         String avatarUrl = StringUtils.isNotBlank(photo)

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ApiParser.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ApiParser.java
@@ -884,7 +884,7 @@ public final class ApiParser {
         String gender = getJsonFieldAsString(node, "gender");
         String updateAt = getJsonFieldAsString(node, "update_at");
         String parentCommentId = getJsonFieldAsString(node, "parent_CID");
-        boolean spoiler = !getJsonFieldAsString(node, "spoiler").equals("1");
+        boolean spoiler = getJsonFieldAsString(node, "spoiler").equals("2");
 
         // 构建完整的用户头像URL: https://{imageDomain}/media/users/{photo}
         String avatarUrl = StringUtils.isNotBlank(photo)

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/HtmlParser.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/HtmlParser.java
@@ -36,6 +36,7 @@ public final class HtmlParser {
     private static final Pattern PATTERN_JM_DOMAIN = Pattern.compile("^(?:https?://)?(?:[^@\\n]+@)?(?:www\\.)?([^:/\\n?]+)");
     public static final Pattern PATTERN_HTML_ALBUM_VIEWS = Pattern.compile("<span>(.*?)</span>\\n *<span>(次觀看|观看次数|次观看次数|次觀看次數|觀看次數|views)</span>");
     public static final Pattern PATTERN_HTML_SEARCH_TOTAL = Pattern.compile("class=\"text-white\">(\\d+)</span> A漫.");
+    private static final Pattern PATTERN_PHOTO_ID = Pattern.compile("/photo/(\\d+)/?");
 
     /**
      * 解析本子详情页 (Album Page)。
@@ -535,6 +536,119 @@ public final class HtmlParser {
             id = "0";
         }
         return new String[]{name, id};
+    }
+
+    /**
+     * 解析 /ajax/album_pagination 返回的评论分页响应。
+     *
+     * @param responseHtml AJAX 响应体
+     * @param albumId      本子 ID
+     * @return 评论列表
+     */
+    public static JmCommentList parseAlbumCommentsAjax(String responseHtml, String albumId) {
+        Document doc = Jsoup.parse(responseHtml);
+        String domain = extractDomain(doc);
+        List<JmComment> comments = parseTimelineComments(doc, albumId, domain);
+        return new JmCommentList(comments.size(), comments);
+    }
+
+    private static String extractDomain(Document doc) {
+        Element userLink = doc.selectFirst("a[href^=https://][href*=/user/]");
+        if (userLink != null) {
+            String href = userLink.attr("href");
+            int pathStart = href.indexOf("/", "https://".length());
+            return pathStart > 0 ? href.substring(0, pathStart) : href;
+        }
+        return "";
+    }
+
+    private static List<JmComment> parseTimelineComments(Document doc, String albumId, String domain) {
+        Elements timelines = doc.select(".timeline-panel > .panel-body > .timeline[data-cid]");
+        if (timelines.isEmpty()) {
+            timelines = doc.select("body > .timeline[data-cid], body > div > .timeline[data-cid], .timeline[data-cid]");
+        }
+        List<JmComment> comments = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (Element timeline : timelines) {
+            String commentId = timeline.attr("data-cid").trim();
+            if (commentId.isEmpty() || !seen.add(commentId)) {
+                continue;
+            }
+            comments.add(parseTimelineComment(timeline, albumId, "", domain));
+        }
+        return comments;
+    }
+
+    private static JmComment parseTimelineComment(Element timeline, String albumId, String parentCommentId, String domain) {
+        String commentId = timeline.attr("data-cid").trim()
+                .replace("{", "").replace("}", "");
+        Element avatar = timeline.selectFirst(".timeline-avatar");
+        String username = "";
+        if (avatar != null) {
+            Element userLink = avatar.parent();
+            if (userLink != null && "a".equals(userLink.tagName())) {
+                String href = userLink.attr("href");
+                if (href.contains("/user/")) {
+                    username = href.substring(href.lastIndexOf("/user/") + "/user/".length());
+                }
+            }
+        }
+        String nickname = ParseHelper.selectFirstText(timeline, ".timeline-username", "comment username");
+        String photo = "";
+        if (avatar != null) {
+            String src = avatar.attr("src");
+            if (StringUtils.isNotBlank(src) && StringUtils.isNotBlank(domain)) {
+                photo = domain + src;
+            }
+        }
+        String expinfo = ParseHelper.selectFirstText(timeline, ".timeline-user-level", "comment user level");
+        String postDate = ParseHelper.selectFirstText(timeline, ".timeline-date", "comment date");
+
+        Element contentElement = timeline.selectFirst(".timeline-content");
+        String content = contentElement != null ? contentElement.text().trim() : "";
+        String contentHtml = contentElement.outerHtml().trim();
+
+        List<JmComment> replies = new ArrayList<>();
+        for (Element reply : timeline.select(".other-timelines > .timeline[data-cid]")) {
+            replies.add(parseTimelineComment(reply, albumId, commentId, domain));
+        }
+
+        String photoId = "";
+        Element photoLink = timeline.selectFirst(".timeline-ft a[href*=/photo/]");
+        if (photoLink != null) {
+            Matcher matcher = PATTERN_PHOTO_ID.matcher(photoLink.attr("href"));
+            if (matcher.find()) {
+                photoId = matcher.group(1);
+            }
+        }
+
+        boolean spoiler = timeline.selectFirst(".disclose") != null;
+
+        return new JmComment(
+                commentId,
+                "",
+                username,
+                nickname,
+                content,
+                contentHtml,
+                postDate,
+                photo,
+                expinfo,
+                JmCommentExpInfo.empty(expinfo),
+                albumId,
+                "",
+                "",
+                photoId,
+                "JM" + albumId,
+                0,
+                "",
+                "",
+                parentCommentId,
+                spoiler,
+                replies,
+                0,
+                0
+        );
     }
 
     /**

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/HtmlParser.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/HtmlParser.java
@@ -582,7 +582,9 @@ public final class HtmlParser {
     private static JmComment parseTimelineComment(Element timeline, String albumId, String parentCommentId, String domain) {
         String commentId = timeline.attr("data-cid").trim()
                 .replace("{", "").replace("}", "");
-        Element avatar = timeline.selectFirst(".timeline-avatar");
+        Element left = timeline.selectFirst("> .timeline-left");
+        Element right = timeline.selectFirst("> .timeline-right");
+        Element avatar = left != null ? left.selectFirst(".timeline-avatar") : null;
         String username = "";
         if (avatar != null) {
             Element userLink = avatar.parent();
@@ -593,7 +595,7 @@ public final class HtmlParser {
                 }
             }
         }
-        String nickname = ParseHelper.selectFirstText(timeline, ".timeline-username", "comment username");
+        String nickname = right != null ? ParseHelper.selectFirstText(right, ".timeline-username", "comment username") : "";
         String photo = "";
         if (avatar != null) {
             String src = avatar.attr("src");
@@ -601,10 +603,10 @@ public final class HtmlParser {
                 photo = domain + src;
             }
         }
-        String expinfo = ParseHelper.selectFirstText(timeline, ".timeline-user-level", "comment user level");
-        String postDate = ParseHelper.selectFirstText(timeline, ".timeline-date", "comment date");
+        String expinfo = left != null ? ParseHelper.selectFirstText(left, ".timeline-user-level", "comment user level") : "";
+        String postDate = right != null ? ParseHelper.selectFirstText(right, ".timeline-date", "comment date") : "";
 
-        Element contentElement = timeline.selectFirst(".timeline-content");
+        Element contentElement = right != null ? right.selectFirst(".timeline-content") : null;
         String content = contentElement != null ? contentElement.text().trim() : "";
         String contentHtml = contentElement != null ? contentElement.outerHtml().trim() : "";
 
@@ -614,7 +616,7 @@ public final class HtmlParser {
         }
 
         String photoId = "";
-        Element photoLink = timeline.selectFirst(".timeline-ft a[href*=/photo/]");
+        Element photoLink = right != null ? right.selectFirst(".timeline-ft a[href*=/photo/]") : null;
         if (photoLink != null) {
             Matcher matcher = PATTERN_PHOTO_ID.matcher(photoLink.attr("href"));
             if (matcher.find()) {
@@ -622,7 +624,7 @@ public final class HtmlParser {
             }
         }
 
-        boolean spoiler = timeline.selectFirst(".disclose") != null;
+        boolean spoiler = right != null && right.selectFirst(".disclose") != null;
 
         return new JmComment(
                 commentId,

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/HtmlParser.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/HtmlParser.java
@@ -565,7 +565,7 @@ public final class HtmlParser {
     private static List<JmComment> parseTimelineComments(Document doc, String albumId, String domain) {
         Elements timelines = doc.select(".timeline-panel > .panel-body > .timeline[data-cid]");
         if (timelines.isEmpty()) {
-            timelines = doc.select("body > .timeline[data-cid], body > div > .timeline[data-cid], .timeline[data-cid]");
+            timelines = doc.select("body > .timeline[data-cid], body > div > .timeline[data-cid], .timeline[data-cid]:not(.other-timelines .timeline)");
         }
         List<JmComment> comments = new ArrayList<>();
         Set<String> seen = new HashSet<>();
@@ -606,7 +606,7 @@ public final class HtmlParser {
 
         Element contentElement = timeline.selectFirst(".timeline-content");
         String content = contentElement != null ? contentElement.text().trim() : "";
-        String contentHtml = contentElement.outerHtml().trim();
+        String contentHtml = contentElement != null ? contentElement.outerHtml().trim() : "";
 
         List<JmComment> replies = new ArrayList<>();
         for (Element reply : timeline.select(".other-timelines > .timeline[data-cid]")) {

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ParseHelper.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ParseHelper.java
@@ -54,8 +54,8 @@ public final class ParseHelper {
                 .stream()
                 .map(Element::text)
                 .map(String::trim)
-                .collect(Collectors.toSet())
-                .stream().toList();
+                .distinct()
+                .toList();
     }
 
     /**

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ParseHelper.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/parser/ParseHelper.java
@@ -54,7 +54,8 @@ public final class ParseHelper {
                 .stream()
                 .map(Element::text)
                 .map(String::trim)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet())
+                .stream().toList();
     }
 
     /**


### PR DESCRIPTION
* **New Features**
  * 实现 JmHtmlClient#getComments 方法
* **Bug Fixes**
  * JM 评论数据模型剧透标记字段改为boolean
  * HTML 客户端解析author、tag 时去重

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持获取本子评论的分页 AJAX 内容，并解析评论、回复、头像、关联图片链接及剧透标记。
* **Bug 修复**
  * 剧透状态现已按开/关进行解析与返回，告别原先的文本判断。
  * 评论文本提取结果会自动去重，减少重复显示。
* **改进**
  * 评论模型与解析接口已同步更新，以提升字段含义与展示的一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->