### PR TITLE
docs(client): JmHtmlClient#getAlbumDownloadInfo 目前无法实现

### DIFF
--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmHtmlClient.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmHtmlClient.java
@@ -436,6 +436,18 @@ public final class JmHtmlClient extends AbstractJmClient implements JmNovelClien
         return HtmlParser.parseSearchPage(jmHtmlResponse.getHtml(), page);
     }
 
+    /**
+     * 获取本子下载信息
+     * <p>api端点 "/album_download/{albumId}"
+     * <p>流程如下:
+     * <p>GET "/album_download/{albumId}" -> 获取页面html
+     * <p>POST "/album_download/{albumId}" {album_id: xxx,verification: xxx} -> 重定向到下载地址url -> GET 下载地址url
+     * <p>验证码获取: GET /captcha/{Math.random()}
+     * <p>网页端需要手动输入验证码，无法直接获取
+     *
+     * @param albumId 本子ID
+     * @return 下载信息
+     */
     @Override
     public JmAlbumDownloadInfo getAlbumDownloadInfo(String albumId) {
         throw new UnsupportedOperationException("Getting album download info via HTML client is not currently supported. Use JmApiClient instead.");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 补充 HTML 端获取本子下载信息的流程说明。
  * 说明验证码获取方式及需手动输入验证码的限制。
  * 未改变现有功能或用户操作方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->