### PR TITLE
fix(client): 修复动态图片域名从未生效（对不可变列表 add() 抛异常）

### DIFF
--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/AbstractJmClient.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/AbstractJmClient.java
@@ -103,7 +103,7 @@ public abstract class AbstractJmClient implements JmClient, JmDownloadClient {
         /*
          * 后台异步初始化：更新域名列表 -> 域名探活排掉死域名 -> 启动定期复探 -> 调子类初始化
          */
-        this.internalExecutor.submit(() -> {
+        this.internalExecutor.execute(() -> {
             try {
                 this.updateDomains();
                 DomainProbe probe = createDomainProbe();
@@ -111,8 +111,9 @@ public abstract class AbstractJmClient implements JmClient, JmDownloadClient {
                 this.domainManager.startPeriodicProbe(probe, config.getDomainProbeIntervalMs());
                 this.domainManager.setInitialized(true);
                 this.initialize();
-            } catch (Throwable e) {
+            } catch (RuntimeException e) {
                 logger.error("后台初始化任务执行失败", e);
+                throw e;
             }
         });
         // 生成一个 128位的 AES 随机密钥

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/AbstractJmClient.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/AbstractJmClient.java
@@ -104,12 +104,16 @@ public abstract class AbstractJmClient implements JmClient, JmDownloadClient {
          * 后台异步初始化：更新域名列表 -> 域名探活排掉死域名 -> 启动定期复探 -> 调子类初始化
          */
         this.internalExecutor.submit(() -> {
-            this.updateDomains();
-            DomainProbe probe = createDomainProbe();
-            this.domainManager.probeAllDomains(probe);
-            this.domainManager.startPeriodicProbe(probe, config.getDomainProbeIntervalMs());
-            this.domainManager.setInitialized(true);
-            this.initialize();
+            try {
+                this.updateDomains();
+                DomainProbe probe = createDomainProbe();
+                this.domainManager.probeAllDomains(probe);
+                this.domainManager.startPeriodicProbe(probe, config.getDomainProbeIntervalMs());
+                this.domainManager.setInitialized(true);
+                this.initialize();
+            } catch (Throwable e) {
+                logger.error("后台初始化任务执行失败", e);
+            }
         });
         // 生成一个 128位的 AES 随机密钥
         try {

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmApiClient.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmApiClient.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.CookieManager;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
 import java.util.List;
@@ -111,9 +112,38 @@ public final class JmApiClient extends AbstractJmClient implements JmNovelClient
             logger.info("当前API客户端版本[{}]，更新API客户端版本[{}] -> [{}]", JmConstants.APP_VERSION, JmConstants.APP_VERSION, JmConstants.APP_VERSION);
         }
 
-        if (imgHost != null && !JmConstants.DEFAULT_IMAGE_DOMAINS.contains(imgHost)) {
-            JmConstants.DEFAULT_IMAGE_DOMAINS.add(imgHost);
-            logger.info("添加动态图片域名[{}]，当前图片域名列表: {}", imgHost, JmConstants.DEFAULT_IMAGE_DOMAINS);
+        String imageHost = normalizeImageHost(imgHost);
+        if (imageHost != null) {
+            boolean added;
+            synchronized (JmConstants.DEFAULT_IMAGE_DOMAINS) {
+                added = !JmConstants.DEFAULT_IMAGE_DOMAINS.contains(imageHost) && JmConstants.DEFAULT_IMAGE_DOMAINS.add(imageHost);
+            }
+            if (added) {
+                logger.info("添加动态图片域名[{}]，当前图片域名列表: {}", imageHost, JmConstants.DEFAULT_IMAGE_DOMAINS);
+            }
+        }
+    }
+
+    /**
+     * 标准化图片域名，提取并返回主机名（Host）。
+     *
+     * @param imgHost 图片URL或主机名，可为任意格式
+     * @return 标准化后的主机名
+     */
+    private static String normalizeImageHost(String imgHost) {
+        if (StringUtils.isBlank(imgHost)) {
+            return null;
+        }
+
+        String value = imgHost.trim();
+        try {
+            URI uri = URI.create(value);
+            if (uri.getScheme() == null) {
+                uri = URI.create(JmConstants.PROTOCOL_HTTPS + value);
+            }
+            return uri.getHost();
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmApiClient.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/client/impl/JmApiClient.java
@@ -111,8 +111,9 @@ public final class JmApiClient extends AbstractJmClient implements JmNovelClient
             logger.info("当前API客户端版本[{}]，更新API客户端版本[{}] -> [{}]", JmConstants.APP_VERSION, JmConstants.APP_VERSION, JmConstants.APP_VERSION);
         }
 
-        if (imgHost != null) {
+        if (imgHost != null && !JmConstants.DEFAULT_IMAGE_DOMAINS.contains(imgHost)) {
             JmConstants.DEFAULT_IMAGE_DOMAINS.add(imgHost);
+            logger.info("添加动态图片域名[{}]，当前图片域名列表: {}", imgHost, JmConstants.DEFAULT_IMAGE_DOMAINS);
         }
     }
 

--- a/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/constant/JmConstants.java
+++ b/jmcomic-core/src/main/java/io/github/jukomu/jmcomic/core/constant/JmConstants.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @author JUKOMU
@@ -126,7 +127,7 @@ public final class JmConstants {
             "www.cdnplaystation6.cc"
     ));
 
-    public static List<String> DEFAULT_IMAGE_DOMAINS = Collections.unmodifiableList(List.of(
+    public static List<String> DEFAULT_IMAGE_DOMAINS = new CopyOnWriteArrayList<>(List.of(
             "cdn-msp.jmapiproxy1.cc",
             "cdn-msp.jmapiproxy2.cc",
             "cdn-msp2.jmapiproxy2.cc",


### PR DESCRIPTION
## 修复问题

Closes #17

`JmApiClient.updateSetting()` 对不可变列表 `JmConstants.DEFAULT_IMAGE_DOMAINS` 调用 `add()`，每次客户端初始化都会抛出 `UnsupportedOperationException`，且异常被后台线程静默吞掉，导致服务端下发的动态图片 CDN 域名从未生效。

## 修改内容

1. **`JmConstants.java`**: `DEFAULT_IMAGE_DOMAINS` 由 `Collections.unmodifiableList(List.of(...))` 改为 `CopyOnWriteArrayList`。该常量会被 `ApiParser` / `JmApiClient` 跨线程并发读取（`RANDOM.nextInt(size())`），`CopyOnWriteArrayList` 提供线程安全的读写，顺带修复了可见性问题。
2. **`JmApiClient.updateSetting()`**: 增加去重判断，避免重复创建客户端时同一域名被反复追加。
3. **`AbstractJmClient` 后台初始化任务**: 增加 `try-catch` + 异常日志，避免后续同类异常继续被 `Future` 静默吞掉，便于排查。

## 验证

- `mvn compile` 全模块编译通过
- 最小复现从抛 `UnsupportedOperationException` 变为正常追加（未加入测试，仓库无现有测试目录）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进后台异步初始化的异常处理，失败时记录错误日志并保持异常状态可见。
  * 优化动态图片域名配置，自动规范化域名格式并忽略空白或无效输入。
  * 避免重复添加图片域名，提升域名更新过程的稳定性与并发安全性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->